### PR TITLE
Added feature to select the team to set line up for when having multiple teams.

### DIFF
--- a/start-active-players-phantom.py
+++ b/start-active-players-phantom.py
@@ -13,9 +13,10 @@ import click
 
 @click.command()
 @click.option('--days', type=int, prompt='Number of days to set active lineup', help='Number of days to set active lineup')
-@click.option('--username', prompt='Your Yahoo username:', help='Your Yahoo account username')
-@click.option('--password', prompt='Your Yahoo passwordname:', help='Your Yahoo account password')
-def start_active_players(days, username, password):
+@click.option('--username', prompt='Your Yahoo username', help='Your Yahoo account username')
+@click.option('--password', prompt='Your Yahoo password', help='Your Yahoo account password')
+@click.option('--teamname', prompt='Which team do you want to set active lineup for? Enter teamname', help='Your Fantasy basketball teamname')
+def start_active_players(days, username, password, teamname):
 	"""Simple python program that sets your active players for the next number DAYS."""
 	print("Logging in as: " + username)
 
@@ -39,8 +40,15 @@ def start_active_players(days, username, password):
 	driver.implicitly_wait(12) # 12 seconds
 	driver.save_screenshot('screenshot.png')
 
-	driver.find_element_by_xpath("//a[text() = 'My Team ']").click()
-	time.sleep(8)
+
+	# hover to Fantasy Basketball to display the hidden dropdown menu 
+	teams = driver.find_element_by_xpath("//li[@class = 'Navitem Navitem-main Navitem-fantasy Va-top Fl-start Topstart']")
+	hov = ActionChains(driver).move_to_element(teams)
+	hov.perform()
+	time.sleep(1)
+
+	driver.find_element_by_xpath("//a[text() = '"+ teamname +"']").click()
+	time.sleep(2)
 
 	for x in range(0, days):
 

--- a/start-active-players.py
+++ b/start-active-players.py
@@ -14,8 +14,9 @@ import click
 @click.option('--days', type=int, prompt='Number of days to set active lineup', help='Number of days to set active lineup')
 @click.option('--username', prompt='Your Yahoo username', help='Your Yahoo account username')
 @click.option('--password', prompt='Your Yahoo passwordname', help='Your Yahoo account password')
+@click.option('--teamname', prompt='Which team do you want to set active lineup for? Enter teamname', help='Your Fantasy basketball teamname')
 @click.option('--headless', type=bool, prompt='Do you want to run in headless mode? [True|False]', help='If True you won\'t see what\'s going on while it\'s running. If false you will see the browser render the steps.')
-def start_active_players(days, username, password, headless):
+def start_active_players(days, username, password, teamname, headless):
 	"""Simple python program that sets your active players for the next number DAYS."""
 	print("Logging in as: " + username)
 
@@ -35,7 +36,14 @@ def start_active_players(days, username, password, headless):
 	time.sleep(8)
 	driver.find_element_by_name('signin').click()
 	time.sleep(8)
-	driver.find_element_by_xpath("//a[text() = 'My Team ']").click()
+
+	# hover to Fantasy Basketball to display the hidden dropdown menu 
+	teams = driver.find_element_by_xpath("//li[@class = 'Navitem Navitem-main Navitem-fantasy Va-top Fl-start Topstart']")
+	hov = ActionChains(driver).move_to_element(teams)
+	hov.perform()
+	time.sleep(1)
+
+	driver.find_element_by_xpath("//a[text() = '"+ teamname +"']").click()
 	time.sleep(2)
 
 	for x in range(0, days):

--- a/start-active-players.py
+++ b/start-active-players.py
@@ -13,7 +13,7 @@ import click
 @click.command()
 @click.option('--days', type=int, prompt='Number of days to set active lineup', help='Number of days to set active lineup')
 @click.option('--username', prompt='Your Yahoo username', help='Your Yahoo account username')
-@click.option('--password', prompt='Your Yahoo passwordname', help='Your Yahoo account password')
+@click.option('--password', prompt='Your Yahoo password', help='Your Yahoo account password')
 @click.option('--teamname', prompt='Which team do you want to set active lineup for? Enter teamname', help='Your Fantasy basketball teamname')
 @click.option('--headless', type=bool, prompt='Do you want to run in headless mode? [True|False]', help='If True you won\'t see what\'s going on while it\'s running. If false you will see the browser render the steps.')
 def start_active_players(days, username, password, teamname, headless):


### PR DESCRIPTION
Added feature to select the team to set line up for when having multiple teams.
Fixed a couple typos in @click prompts.

Bug:
Getting the 'My Team ' section doesn't work in the original code, possibly due to the extra space. 
Also, when user have multiple fantasy basketball teams, original code can only set line up for the first team under 'My Team'.

The fix is: instead of click into My team, we now hover over 'fantasy basketball' (identified by element-li and [@class]), then in the drop-down menu, we click into the path that match the teamname specified by the user, and start setting line ups from there.
